### PR TITLE
Fix dynamic force labels rendering

### DIFF
--- a/Problem1.html
+++ b/Problem1.html
@@ -314,7 +314,11 @@
         function addLabel(arrow, text) {
             const labelDiv = document.createElement('div');
             labelDiv.className = 'label';
-            labelDiv.innerHTML = '$$' + text + '$$'; // Оборачиваем в $$ для рендеринга KaTeX
+            if (window.katex) {
+                window.katex.render(text, labelDiv, { throwOnError: false });
+            } else {
+                labelDiv.textContent = text;
+            }
             const label = new CSS2DObject(labelDiv);
             const endOfArrow = new THREE.Vector3(0, 0, 0); // Начало стрелки в локальных координатах
             endOfArrow.add(arrow.line.position); // Позиция линии


### PR DESCRIPTION
## Summary
- render force labels with KaTeX so subscripts like `F_g` display correctly

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a467f6b588328bba2d55c5e641c29